### PR TITLE
Adds support for custom CSS and JS per post

### DIFF
--- a/_includes/head/custom.html
+++ b/_includes/head/custom.html
@@ -2,4 +2,17 @@
 
 <!-- insert favicons. use https://realfavicongenerator.net/ -->
 
+  {% if page.custom_css %}
+    {% for stylesheet in page.custom_css %}
+    <link rel="stylesheet" href="{{ site.baseurl }}/assets/css/{{ stylesheet }}.css">
+    {% endfor %}
+  {% endif %}
+  
+  {% if page.custom_js %}
+    {% for js_file in page.custom_js %}
+    <script type="text/javascript" src="{{ site.baseurl }}/assets/js/{{ js_file }}.js"></script>
+    {% endfor %}
+  {% endif %}
+  
+  
 <!-- end custom head snippets -->

--- a/_posts/2020-05-11-text-classification-using-sklearn-and-nltk.md
+++ b/_posts/2020-05-11-text-classification-using-sklearn-and-nltk.md
@@ -5,6 +5,7 @@ classes: wide
 # TODO: find out why tags aren't working
 tags: [NLP, sklearn, NLTK]
 toc: true
+custom_css: lime
 ---
 
 <style type="text/css">

--- a/assets/css/lime.css
+++ b/assets/css/lime.css
@@ -1,0 +1,11 @@
+div.lime {
+    color: white;
+}
+
+div.lime svg text {
+    fill: white;
+}
+
+div.lime svg g text {
+    fill: white;
+}


### PR DESCRIPTION
Following this guide:
https://jreel.github.io/per-page-custom-css-in-jekyll/

I added support for custom CSS and JS, and used that to apply some custom styling for lime visualizations.
The styling is pretty basic and serves as an example, please change as you see fit!